### PR TITLE
Update PHP MailerMailer API Wrapper to support UTF8 chars

### DIFF
--- a/LICENSE.php
+++ b/LICENSE.php
@@ -5,7 +5,7 @@
  *
  * @package   mailermailer-api-php
  * @author    MailerMailer <support@mailermailer.com>
- * @copyright 2001-2014 MailerMailer LLC
+ * @copyright 2001-2016 MailerMailer LLC
  * @license   This program is free software; you can redistribute it and/or modify
  *            it under the terms of the GNU General Public License as published by
  
@@ -21,7 +21,7 @@
  *            along with this program; if not, write to the Free Software
  *            Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
  *            MA 02110-1301, USA.
- * @version   1.0.5
+ * @version   1.0.6
  * @link      http://www.mailermailer.com/api/index.rwp
  */
 

--- a/MAILAPI_Call.php
+++ b/MAILAPI_Call.php
@@ -34,20 +34,20 @@ class MAILAPI_Call
         $host = getenv("MAILAPI_URL") ? getenv("MAILAPI_URL") : MAILAPI_ENDPOINT;
 
         $params['apikey'] = new xmlrpcval($this->apikey);
-        
+
         $xmlrpcmsg = new xmlrpcmsg($method, array(new xmlrpcval($params, 'struct')));
+
         $xmlrpc_client = new xmlrpc_client($host);
         $xmlrpc_client->SetUserAgent(MAILAPI_PARTNER . "/PHP/v" . MAILAPI_VERSION);
 
         $response = $xmlrpc_client->send($xmlrpcmsg);
 
         if (!$response->faultCode()) {
-            return $response->value();
+           return php_xmlrpc_decode($response->value());
         } else {
-            $value = $response->value();
             return new MAILAPI_Error($response->faultCode(), $response->faultString());
         }
-    }   
+    }
 }
 
 ?>

--- a/MAILAPI_Call.php
+++ b/MAILAPI_Call.php
@@ -9,6 +9,11 @@ require_once('config.php');
 require_once('MAILAPI_Error.php');
 
 /**
+ *  Override the default internal encoding declared within xmlrpc.inc
+ */
+$xmlrpc_internalencoding = "UTF-8";
+
+/**
  * Class that performs all the required work to
  * connect to the Mail API.
  */
@@ -38,6 +43,7 @@ class MAILAPI_Call
         $xmlrpcmsg = new xmlrpcmsg($method, array(new xmlrpcval($params, 'struct')));
 
         $xmlrpc_client = new xmlrpc_client($host);
+        $xmlrpc_client->request_charset_encoding="UTF-8";
         $xmlrpc_client->SetUserAgent(MAILAPI_PARTNER . "/PHP/v" . MAILAPI_VERSION);
 
         $response = $xmlrpc_client->send($xmlrpcmsg);

--- a/MAILAPI_Client.php
+++ b/MAILAPI_Client.php
@@ -29,8 +29,8 @@ class MAILAPI_Client
     public function ping()
     {
         $params = array();
-        $response = $this->mailapi_call->executeMethod('ping', $params);
-        return MAILAPI_Client::getResult($response);
+        $result = $this->mailapi_call->executeMethod('ping', $params);
+        return $result;
     }
 
     /**
@@ -41,8 +41,8 @@ class MAILAPI_Client
     public function getFormFields()
     {
         $params = array();
-        $response = $this->mailapi_call->executeMethod('getFormFields', $params);
-        return MAILAPI_Client::getResult($response);
+        $result = $this->mailapi_call->executeMethod('getFormFields', $params);
+        return $result;
     }
 
     /**
@@ -63,8 +63,8 @@ class MAILAPI_Client
         $params['send_welcome']     = php_xmlrpc_encode($send_welcome);
         $params['update_existing']  = php_xmlrpc_encode($update_existing);
         $params['enforce_required'] = php_xmlrpc_encode($enforce_required);
-        $response = $this->mailapi_call->executeMethod('addBulkMembers', $params);
-        return MAILAPI_Client::getResult($response);
+        $result = $this->mailapi_call->executeMethod('addBulkMembers', $params);
+        return $result;
     }
 
     /**
@@ -85,8 +85,8 @@ class MAILAPI_Client
         $params['send_welcome']     = php_xmlrpc_encode($send_welcome);
         $params['update_existing']  = php_xmlrpc_encode($update_existing);
         $params['enforce_required'] = php_xmlrpc_encode($enforce_required);
-        $response = $this->mailapi_call->executeMethod('addMember', $params);
-        return MAILAPI_Client::getResult($response);
+        $result = $this->mailapi_call->executeMethod('addMember', $params);
+        return $result;
     }
 
     /**
@@ -99,8 +99,8 @@ class MAILAPI_Client
     {
         $params                 = array();
         $params['user_emails']   = php_xmlrpc_encode($user_emails);
-        $response = $this->mailapi_call->executeMethod('unsubBulkMembers', $params);
-        return MAILAPI_Client::getResult($response);
+        $result = $this->mailapi_call->executeMethod('unsubBulkMembers', $params);
+        return $result;
     }
 
     /**
@@ -113,8 +113,8 @@ class MAILAPI_Client
     {
         $params                 = array();
         $params['user_email']   = php_xmlrpc_encode($user_email);
-        $response = $this->mailapi_call->executeMethod('unsubMember', $params);
-        return MAILAPI_Client::getResult($response);
+        $result = $this->mailapi_call->executeMethod('unsubMember', $params);
+        return $result;
     }
 
     /**
@@ -127,8 +127,8 @@ class MAILAPI_Client
     {
         $params                 = array();
         $params['user_email']   = php_xmlrpc_encode($user_email);
-        $response = $this->mailapi_call->executeMethod('suppressMember', $params);
-        return MAILAPI_Client::getResult($response);
+        $result = $this->mailapi_call->executeMethod('suppressMember', $params);
+        return $result;
     }
 
     /**
@@ -141,26 +141,9 @@ class MAILAPI_Client
     {
         $params                 = array();
         $params['user_email']   = php_xmlrpc_encode($user_email);
-        $response = $this->mailapi_call->executeMethod('unsuppressMember', $params);
-        return MAILAPI_Client::getResult($response);
-    }
-
-    /**
-     * Formats the response as necessary.
-     *
-     * @param  mixed $response xmlrpc encoded response from server
-     * @return mixed
-     * @static
-     */
-    static function getResult($response)
-    {        
-        if (!MAILAPI_Error::isError($response)) {
-            return php_xmlrpc_decode($response);
-        } else {
-            return $response;
-        }
+        $result = $this->mailapi_call->executeMethod('unsuppressMember', $params);
+        return $result;
     }
 }
-
 
 ?>

--- a/config.php
+++ b/config.php
@@ -5,7 +5,7 @@
 
 define('MAILAPI_ENDPOINT', 'https://api.mailermailer.com/1.0/');
 
-define('MAILAPI_VERSION', '1.0.5');
+define('MAILAPI_VERSION', '1.0.6');
 
 define ('MAILAPI_PARTNER', 'MM');
 

--- a/xmlrpc/xmlrpc.inc
+++ b/xmlrpc/xmlrpc.inc
@@ -1,7 +1,6 @@
 <?php
 // by Edd Dumbill (C) 1999-2002
 // <edd@usefulinc.com>
-// $Id: xmlrpc.inc,v 1.174 2009/03/16 19:36:38 ggiunta Exp $
 
 // Copyright (c) 1999,2000,2002 Edd Dumbill.
 // All rights reserved.
@@ -209,7 +208,7 @@
 	$GLOBALS['xmlrpc_internalencoding']='ISO-8859-1';
 
 	$GLOBALS['xmlrpcName']='XML-RPC for PHP';
-	$GLOBALS['xmlrpcVersion']='3.0.0.beta';
+	$GLOBALS['xmlrpcVersion']='3.0.1';
 
 	// let user errors start at 800
 	$GLOBALS['xmlrpcerruser']=800;
@@ -226,6 +225,7 @@
 
 	// set to TRUE to enable encoding of php NULL values to <EX:NIL/> instead of <NIL/>
 	$GLOBALS['xmlrpc_null_apache_encoding']=false;
+	$GLOBALS['xmlrpc_null_apache_encoding_ns']='http://ws.apache.org/xmlrpc/namespaces/extensions';
 
 	// used to store state during parsing
 	// quick explanation of components:
@@ -820,7 +820,7 @@
 		var $key='';
 		var $keypass='';
 		var $verifypeer=true;
-		var $verifyhost=2;
+		var $verifyhost=1;
 		var $no_multicall=false;
 		var $proxy='';
 		var $proxyport=0;
@@ -850,7 +850,7 @@
 		* http://curl.haxx.se/docs/faq.html#7.3)
 		*/
 		var $xmlrpc_curl_handle = null;
-		/// Wheter to use persistent connections for http 1.1 and https
+		/// Whether to use persistent connections for http 1.1 and https
 		var $keepalive = false;
 		/// Charset encodings that can be decoded without problems by the client
 		var $accepted_charset_encodings = array();
@@ -944,7 +944,7 @@
 
 		/**
 		* Enables/disables the echoing to screen of the xmlrpc responses received
-		* @param integer $debug values 0, 1 and 2 are supported (2 = echo sent msg too, before received response)
+		* @param integer $in values 0, 1 and 2 are supported (2 = echo sent msg too, before received response)
 		* @access public
 		*/
 		function setDebug($in)
@@ -980,7 +980,7 @@
 
 		/**
 		* Add a CA certificate to verify server with (see man page about
-		* CURLOPT_CAINFO for more details
+		* CURLOPT_CAINFO for more details)
 		* @param string $cacert certificate file name (or dir holding certificates)
 		* @param bool $is_dir set to true to indicate cacert is a dir. defaults to false
 		* @access public
@@ -1062,7 +1062,10 @@
 			if ($compmethod == 'any')
 				$this->accepted_compression = array('gzip', 'deflate');
 			else
-				$this->accepted_compression = array($compmethod);
+				if ($compmethod == false )
+					$this->accepted_compression = array();
+				else
+					$this->accepted_compression = array($compmethod);
 		}
 
 		/**
@@ -1109,7 +1112,7 @@
 		/**
 		* Directly set cURL options, for extra flexibility
 		* It allows eg. to bind client to a specific IP interface / address
-		* @param $options array
+		* @param array $options
 		*/
 		function SetCurlOptions( $options )
 		{
@@ -1342,9 +1345,12 @@
 				$cookieheader = 'Cookie:' . $version . substr($cookieheader, 0, -1) . "\r\n";
 			}
 
+			// omit port if 80
+			$port = ($port == 80) ? '' : (':' . $port);
+
 			$op= 'POST ' . $uri. " HTTP/1.0\r\n" .
 				'User-Agent: ' . $this->user_agent . "\r\n" .
-				'Host: '. $server . ':' . $port . "\r\n" .
+				'Host: '. $server . $port . "\r\n" .
 				$credentials .
 				$proxy_credentials .
 				$accepted_encoding .
@@ -1393,11 +1399,11 @@
 			}
 			else
 			{
-				// reset errno and errstr on succesful socket connection
+				// reset errno and errstr on successful socket connection
 				$this->errstr = '';
 			}
 			// G. Giunta 2005/10/24: close socket before parsing.
-			// should yeld slightly better execution times, and make easier recursive calls (e.g. to follow http redirects)
+			// should yield slightly better execution times, and make easier recursive calls (e.g. to follow http redirects)
 			$ipd='';
 			do
 			{
@@ -1535,7 +1541,6 @@
 			// return the header too
 			curl_setopt($curl, CURLOPT_HEADER, 1);
 
-			// will only work with PHP >= 5.0
 			// NB: if we set an empty string, CURL will add http header indicating
 			// ALL methods it is supporting. This is possibly a better option than
 			// letting the user tell what curl can / cannot do...
@@ -1616,6 +1621,13 @@
 				{
 					curl_setopt($curl, CURLOPT_SSLKEYPASSWD, $keypass);
 				}
+
+				// Upgrade transparently to more stringent check for versions of php which do not support otherwise.
+				// Doing it in constructor would be cleaner; doing it here saves us a couple of function calls
+				if($this->verifyhost == 1 && $info = curl_version() && version_compare($info['version'], '7.28.1') >= 0)
+				{
+					$this->verifyhost = 2;
+				}
 				// whether to verify cert's common name (CN); 0 for no, 1 to verify that it exists, and 2 to verify that it matches the hostname used
 				curl_setopt($curl, CURLOPT_SSL_VERIFYHOST, $this->verifyhost);
 			}
@@ -1667,7 +1679,14 @@
 			{
 				print "<PRE>\n---CURL INFO---\n";
 				foreach(curl_getinfo($curl) as $name => $val)
-					 print $name . ': ' . htmlentities($val). "\n";
+				{
+					if (is_array($val))
+					{
+						$val = implode("\n", $val);
+					}
+					print $name . ': ' . htmlentities($val) . "\n";
+				}
+
 				print "---END---\n</PRE>";
 			}
 
@@ -1688,6 +1707,12 @@
 					curl_close($curl);
 				}
 				$resp =& $msg->parseResponse($result, true, $this->return_type);
+				// if we got back a 302, we can not reuse the curl handle for later calls
+				if($resp->faultCode() == $GLOBALS['xmlrpcerr']['http_error'] && $keepalive)
+				{
+					curl_close($curl);
+					$this->xmlrpc_curl_handle = null;
+				}
 			}
 			return $resp;
 		}
@@ -1710,20 +1735,18 @@
 		* @param array $msgs an array of xmlrpcmsg objects
 		* @param integer $timeout connection timeout (in seconds)
 		* @param string $method the http protocol variant to be used
-		* @param boolean fallback When true, upon receiveing an error during multicall, multiple single calls will be attempted
+		* @param boolean fallback When true, upon receiving an error during multicall, multiple single calls will be attempted
 		* @return array
 		* @access public
 		*/
 		function multicall($msgs, $timeout=0, $method='', $fallback=true)
 		{
-			//echo"";
 			if ($method == '')
 			{
 				$method = $this->method;
 			}
 			if(!$this->no_multicall)
 			{
-				
 				$results = $this->_try_multicall($msgs, $timeout, $method);
 				if(is_array($results))
 				{
@@ -1791,7 +1814,6 @@
 		function _try_multicall($msgs, $timeout, $method)
 		{
 			// Construct multicall message
-			
 			$calls = array();
 			foreach($msgs as $msg)
 			{
@@ -1800,15 +1822,11 @@
 				$params = array();
 				for($i = 0; $i < $numParams; $i++)
 				{
-
 					$params[$i] = $msg->getParam($i);
-					
 				}
 				$call['params'] = new xmlrpcval($params, 'array');
 				$calls[] = new xmlrpcval($call, 'struct');
 			}
-			
-			
 			$multicall = new xmlrpcmsg('system.multicall');
 			$multicall->addParam(new xmlrpcval($calls, 'array'));
 
@@ -2024,7 +2042,7 @@
 		* with attributes being e.g. 'expires', 'path', domain'.
 		* NB: cookies sent as 'expired' by the server (i.e. with an expiry date in the past)
 		* are still present in the array. It is up to the user-defined code to decide
-		* how to use the received cookies, and wheter they have to be sent back with the next
+		* how to use the received cookies, and whether they have to be sent back with the next
 		* request to the server (using xmlrpc_client::setCookie) or not
 		* @return array array of cookies received from the server
 		* @access public
@@ -2046,7 +2064,14 @@
 				$this->content_type = 'text/xml; charset=' . $charset_encoding;
 			else
 				$this->content_type = 'text/xml';
+			if ($GLOBALS['xmlrpc_null_apache_encoding'])
+			{
+				$result = "<methodResponse xmlns:ex=\"".$GLOBALS['xmlrpc_null_apache_encoding_ns']."\">\n";
+			}
+			else
+			{
 			$result = "<methodResponse>\n";
+			}
 			if($this->errno)
 			{
 				// G. Giunta 2005/2/13: let non-ASCII response messages be tolerated by clients
@@ -2096,13 +2121,13 @@ xmlrpc_encode_entitites($this->errstr, $GLOBALS['xmlrpc_internalencoding'], $cha
 
 		/**
 		* @param string $meth the name of the method to invoke
-		* @param array $pars array of parameters to be paased to the method (xmlrpcval objects)
+		* @param array $pars array of parameters to be passed to the method (xmlrpcval objects)
 		*/
 		function xmlrpcmsg($meth, $pars=0)
 		{
 			$this->methodname=$meth;
 			if(is_array($pars) && count($pars)>0)
-			{	
+			{
 				for($i=0; $i<count($pars); $i++)
 				{
 					$this->addParam($pars[$i]);
@@ -2151,7 +2176,7 @@ xmlrpc_encode_entitites($this->errstr, $GLOBALS['xmlrpc_internalencoding'], $cha
 			else
 				$this->content_type = 'text/xml';
 			$this->payload=$this->xml_header($charset_encoding);
-			$this->payload.='<methodName>' . $this->methodname . "</methodName>\n";
+			$this->payload.='<methodName>' . xmlrpc_encode_entitites($this->methodname, $GLOBALS['xmlrpc_internalencoding'], $charset_encoding) . "</methodName>\n";
 			$this->payload.="<params>\n";
 			for($i=0; $i<count($this->params); $i++)
 			{
@@ -2180,6 +2205,7 @@ xmlrpc_encode_entitites($this->errstr, $GLOBALS['xmlrpc_internalencoding'], $cha
 
 		/**
 		* Returns xml representation of the message. XML prologue included
+		* @param string $charset_encoding
 		* @return string the xml representation of the message, xml prologue included
 		* @access public
 		*/
@@ -2200,13 +2226,11 @@ xmlrpc_encode_entitites($this->errstr, $GLOBALS['xmlrpc_internalencoding'], $cha
 			// add check: do not add to self params which are not xmlrpcvals
 			if(is_object($par) && is_a($par, 'xmlrpcval'))
 			{
-				
 				$this->params[]=$par;
 				return true;
 			}
 			else
 			{
-				
 				return false;
 			}
 		}
@@ -2235,6 +2259,7 @@ xmlrpc_encode_entitites($this->errstr, $GLOBALS['xmlrpc_internalencoding'], $cha
 		*      infinite loop in that case, because we cannot trust the caller
 		*      to give us a valid pointer to an open file...
 		* @access public
+		* @param resource $fp stream pointer
 		* @return xmlrpcresp
 		* @todo add 2nd & 3rd param to be passed to ParseResponse() ???
 		*/
@@ -2574,17 +2599,24 @@ xmlrpc_encode_entitites($this->errstr, $GLOBALS['xmlrpc_internalencoding'], $cha
 			$GLOBALS['_xh']['isf_reason']='';
 			$GLOBALS['_xh']['rt']=''; // 'methodcall or 'methodresponse'
 
-			// if response charset encoding is not known / supported, try to use
-			// the default encoding and parse the xml anyway, but log a warning...
-			if (!in_array($resp_encoding, array('UTF-8', 'ISO-8859-1', 'US-ASCII')))
-			// the following code might be better for mb_string enabled installs, but
+			// Since parsing will fail if charset is not specified in the xml prologue,
+			// the encoding is not UTF8 and there are non-ascii chars in the text, we try to work round that...
+			// The following code might be better for mb_string enabled installs, but
 			// makes the lib about 200% slower...
-			//if (!is_valid_charset($resp_encoding, array('UTF-8', 'ISO-8859-1', 'US-ASCII')))
-			{
-				error_log('XML-RPC: '.__METHOD__.': invalid charset encoding of received response: '.$resp_encoding);
-				$resp_encoding = $GLOBALS['xmlrpc_defencoding'];
+			//if (!is_valid_charset($resp_encoding, array('UTF-8')))
+			if (!in_array($resp_encoding, array('UTF-8', 'US-ASCII')) && !has_encoding($data)) {
+				if ($resp_encoding == 'ISO-8859-1') {
+					$data = utf8_encode($data);
+				} else {
+					if (extension_loaded('mbstring')) {
+						$data = mb_convert_encoding($data, 'UTF-8', $resp_encoding);
+					} else {
+						error_log('XML-RPC: ' . __METHOD__ . ': invalid charset encoding of received request: ' . $resp_encoding);
+					}
+				}
 			}
-			$parser = xml_parser_create($resp_encoding);
+
+			$parser = xml_parser_create();
 			xml_parser_set_option($parser, XML_OPTION_CASE_FOLDING, true);
 			// G. Giunta 2005/02/13: PHP internally uses ISO-8859-1, so we have to tell
 			// the xml parser to give us back data in the expected charset.
@@ -3064,7 +3096,7 @@ xmlrpc_encode_entitites($this->errstr, $GLOBALS['xmlrpc_internalencoding'], $cha
 		}
 
 		/**
-		* Checks wheter a struct member with a given name is present.
+		* Checks whether a struct member with a given name is present.
 		* Works only on xmlrpcvals of type struct.
 		* @param string $m the name of the struct member to be looked up
 		* @return boolean
@@ -3541,8 +3573,28 @@ xmlrpc_encode_entitites($this->errstr, $GLOBALS['xmlrpc_internalencoding'], $cha
 		$GLOBALS['_xh']['isf_reason'] = '';
 		$GLOBALS['_xh']['method'] = false;
 		$GLOBALS['_xh']['rt'] = '';
-		/// @todo 'guestimate' encoding
-		$parser = xml_parser_create();
+
+		// 'guestimate' encoding
+		$val_encoding = guess_encoding('', $xml_val);
+
+		// Since parsing will fail if charset is not specified in the xml prologue,
+		// the encoding is not UTF8 and there are non-ascii chars in the text, we try to work round that...
+		// The following code might be better for mb_string enabled installs, but
+		// makes the lib about 200% slower...
+		//if (!is_valid_charset($val_encoding, array('UTF-8')))
+		if (!in_array($val_encoding, array('UTF-8', 'US-ASCII')) && !has_encoding($xml_val)) {
+			if ($val_encoding == 'ISO-8859-1') {
+				$xml_val = utf8_encode($xml_val);
+			} else {
+				if (extension_loaded('mbstring')) {
+					$xml_val = mb_convert_encoding($xml_val, 'UTF-8', $val_encoding);
+				} else {
+					error_log('XML-RPC: ' . __METHOD__ . ': invalid charset encoding of received request: ' . $val_encoding);
+				}
+			}
+		}
+
+        $parser = xml_parser_create();
 		xml_parser_set_option($parser, XML_OPTION_CASE_FOLDING, true);
 		// What if internal encoding is not in one of the 3 allowed?
 		// we use the broadest one, ie. utf8!
@@ -3663,9 +3715,10 @@ xmlrpc_encode_entitites($this->errstr, $GLOBALS['xmlrpc_internalencoding'], $cha
 	* we SHOULD assume it is strictly US-ASCII. But we try to be more tolerant of unconforming (legacy?) clients/servers,
 	* which will be most probably using UTF-8 anyway...
 	*
-	* @param string $httpheaders the http Content-type header
+	* @param string $httpheader the http Content-type header
 	* @param string $xmlchunk xml content buffer
 	* @param string $encoding_prefs comma separated list of character encodings to be used as default (when mb extension is enabled)
+	* @return string
 	*
 	* @todo explore usage of mb_http_input(): does it detect http headers + post data? if so, use it instead of hand-detection!!!
 	*/
@@ -3754,10 +3807,48 @@ xmlrpc_encode_entitites($this->errstr, $GLOBALS['xmlrpc_internalencoding'], $cha
 	}
 
 	/**
+	 * Helper function: checks if an xml chunk as a charset declaration (BOM or in the xml declaration)
+	 *
+	 * @param string $xmlChunk
+	 * @return bool
+	 */
+	function has_encoding($xmlChunk)
+	{
+		// scan the first bytes of the data for a UTF-16 (or other) BOM pattern
+		//	 (source: http://www.w3.org/TR/2000/REC-xml-20001006)
+		if (preg_match('/^(\x00\x00\xFE\xFF|\xFF\xFE\x00\x00|\x00\x00\xFF\xFE|\xFE\xFF\x00\x00)/', $xmlChunk))
+		{
+			return true;
+		}
+		elseif (preg_match('/^(\xFE\xFF|\xFF\xFE)/', $xmlChunk))
+		{
+			return true;
+		}
+		elseif (preg_match('/^(\xEF\xBB\xBF)/', $xmlChunk))
+		{
+			return true;
+		}
+
+		// test if encoding is specified in the xml declaration
+		// Details:
+		// SPACE:		 (#x20 | #x9 | #xD | #xA)+ === [ \x9\xD\xA]+
+		// EQ:			SPACE?=SPACE? === [ \x9\xD\xA]*=[ \x9\xD\xA]*
+		if (preg_match('/^<\?xml\s+version\s*=\s*' . "((?:\"[a-zA-Z0-9_.:-]+\")|(?:'[a-zA-Z0-9_.:-]+'))" .
+			'\s+encoding\s*=\s*' . "((?:\"[A-Za-z][A-Za-z0-9._-]*\")|(?:'[A-Za-z][A-Za-z0-9._-]*'))/",
+			$xmlChunk, $matches))
+		{
+			return true;
+		}
+
+		return false;
+	}
+
+	/**
 	* Checks if a given charset encoding is present in a list of encodings or
 	* if it is a valid subset of any encoding in the list
 	* @param string $encoding charset to be tested
 	* @param mixed $validlist comma separated list of valid charsets (or array of charsets)
+	* @return bool
 	*/
 	function is_valid_charset($encoding, $validlist)
 	{
@@ -3778,7 +3869,7 @@ xmlrpc_encode_entitites($this->errstr, $GLOBALS['xmlrpc_internalencoding'], $cha
 				foreach ($validlist as $allowed)
 					if (in_array($allowed, $charset_supersets[$encoding]))
 						return true;
-				return false;
+			return false;
 		}
 	}
 

--- a/xmlrpc/xmlrpc_wrappers.inc
+++ b/xmlrpc/xmlrpc_wrappers.inc
@@ -3,9 +3,8 @@
  * PHP-XMLRPC "wrapper" functions
  * Generate stubs to transparently access xmlrpc methods as php functions and viceversa
  *
- * @version $Id: xmlrpc_wrappers.inc,v 1.13 2008/09/20 01:23:47 ggiunta Exp $
  * @author Gaetano Giunta
- * @copyright (C) 2006-2009 G. Giunta
+ * @copyright (C) 2006-2014 G. Giunta
  * @license code licensed under the BSD License: http://phpxmlrpc.sourceforge.net/license.txt
  *
  * @todo separate introspection from code generation for func-2-method wrapping
@@ -106,7 +105,6 @@
 	* carried out by the lib, while datetime vals are passed around as strings)
 	*
 	* Known limitations:
-	* - requires PHP 5.0.3 +
 	* - only works for user-defined functions, not for PHP internal functions
 	*   (reflection does not support retrieving number/type of params for those)
 	* - functions returning php objects will generate special xmlrpc responses:
@@ -150,14 +148,7 @@
 		$decode_php_objects = isset($extra_options['decode_php_objs']) ? (bool)$extra_options['decode_php_objs'] : false;
 		$catch_warnings = isset($extra_options['suppress_warnings']) && $extra_options['suppress_warnings'] ? '@' : '';
 
-		if(version_compare(phpversion(), '5.0.3') == -1)
-		{
-			// up to php 5.0.3 some useful reflection methods were missing
-			error_log('XML-RPC: cannot not wrap php functions unless running php version bigger than 5.0.3');
-			return false;
-		}
-
-        $exists = false;
+		$exists = false;
 	    if (is_string($funcname) && strpos($funcname, '::') !== false)
 	    {
 	        $funcname = explode('::', $funcname);
@@ -178,11 +169,6 @@
                 $plainfuncname = get_class($funcname[0]) . '->' . $funcname[1];
             }
             $exists = method_exists($funcname[0], $funcname[1]);
-            if (!$exists && version_compare(phpversion(), '5.1') < 0)
-            {
-               // workaround for php 5.0: static class methods are not seen by method_exists
-               $exists = is_callable( $funcname );
-            }
         }
         else
         {
@@ -240,8 +226,7 @@
     				error_log('XML-RPC: method to be wrapped is the constructor: '.$plainfuncname);
     				return false;
     			}
-			    // php 503 always says isdestructor = true...
-                if( version_compare(phpversion(), '5.0.3') != 0 && $func->isDestructor())
+                if($func->isDestructor())
     			{
     				error_log('XML-RPC: method to be wrapped is the destructor: '.$plainfuncname);
     				return false;
@@ -501,13 +486,6 @@
 		$methodfilter = isset($extra_options['method_filter']) ? $extra_options['method_filter'] : '';
 		$methodtype = isset($extra_options['method_type']) ? $extra_options['method_type'] : 'auto';
 
-        if(version_compare(phpversion(), '5.0.3') == -1)
-		{
-			// up to php 5.0.3 some useful reflection methods were missing
-			error_log('XML-RPC: cannot not wrap php functions unless running php version bigger than 5.0.3');
-			return false;
-		}
-
         $result = array();
 		$mlist = get_class_methods($classname);
 		foreach($mlist as $mname)
@@ -537,12 +515,12 @@
 	* Given an xmlrpc client and a method name, register a php wrapper function
 	* that will call it and return results using native php types for both
 	* params and results. The generated php function will return an xmlrpcresp
-	* oject for failed xmlrpc calls
+	* object for failed xmlrpc calls
 	*
 	* Known limitations:
 	* - server must support system.methodsignature for the wanted xmlrpc method
 	* - for methods that expose many signatures, only one can be picked (we
-	*   could in priciple check if signatures differ only by number of params
+	*   could in principle check if signatures differ only by number of params
 	*   and not by type, but it would be more complication than we can spare time)
 	* - nested xmlrpc params: the caller of the generated php function has to
 	*   encode on its own the params passed to the php function if these are structs
@@ -558,11 +536,11 @@
 	*
 	* @param xmlrpc_client $client     an xmlrpc client set up correctly to communicate with target server
 	* @param string        $methodname the xmlrpc method to be mapped to a php function
-	* @param array         $extra_options array of options that specify conversion details. valid ptions include
+	* @param array         $extra_options array of options that specify conversion details. valid options include
 	*        integer       signum      the index of the method signature to use in mapping (if method exposes many sigs)
 	*        integer       timeout     timeout (in secs) to be used when executing function/calling remote method
 	*        string        protocol    'http' (default), 'http11' or 'https'
-	*        string        new_function_name the name of php function to create. If unsepcified, lib will pick an appropriate name
+	*        string        new_function_name the name of php function to create. If unspecified, lib will pick an appropriate name
 	*        string        return_source if true return php code w. function definition instead fo function name
 	*        bool          encode_php_objs let php objects be sent to server using the 'improved' xmlrpc notation, so server can deserialize them as php objects
 	*        bool          decode_php_objs --- WARNING !!! possible security hazard. only use it with trusted servers ---
@@ -592,6 +570,7 @@
 
 		$encode_php_objects = isset($extra_options['encode_php_objs']) ? (bool)$extra_options['encode_php_objs'] : false;
 		$decode_php_objects = isset($extra_options['decode_php_objs']) ? (bool)$extra_options['decode_php_objs'] : false;
+		// it seems like the meaning of 'simple_client_copy' here is swapped wrt client_copy_mode later on...
 		$simple_client_copy = isset($extra_options['simple_client_copy']) ? (int)($extra_options['simple_client_copy']) : 0;
 		$buildit = isset($extra_options['return_source']) ? !($extra_options['return_source']) : true;
 		$prefix = isset($extra_options['prefix']) ? $extra_options['prefix'] : 'xmlrpc';

--- a/xmlrpc/xmlrpcs.inc
+++ b/xmlrpc/xmlrpcs.inc
@@ -1,7 +1,6 @@
 <?php
 // by Edd Dumbill (C) 1999-2002
 // <edd@usefulinc.com>
-// $Id: xmlrpcs.inc,v 1.71 2008/10/29 23:41:28 ggiunta Exp $
 
 // Copyright (c) 1999,2000,2002 Edd Dumbill.
 // All rights reserved.
@@ -421,7 +420,7 @@
 	/**
 	* Add a string to the debug info that can be later seralized by the server
 	* as part of the response message.
-	* Note that for best compatbility, the debug string should be encoded using
+	* Note that for best compatibility, the debug string should be encoded using
 	* the $GLOBALS['xmlrpc_internalencoding'] character set.
 	* @param string $m
 	* @access public
@@ -451,7 +450,7 @@
 		* @see php_xmlrpc_encode for a list of values
 		*/
 		var $phpvals_encoding_options = array( 'auto_dates' );
-		/// controls wether the server is going to echo debugging messages back to the client as comments in response body. valid values: 0,1,2,3
+		/// controls whether the server is going to echo debugging messages back to the client as comments in response body. valid values: 0,1,2,3
 		var $debug = 1;
 		/**
 		* Controls behaviour of server when invoked user function throws an exception:
@@ -495,8 +494,8 @@
 		var $user_data = null;
 
 		/**
-		* @param array $dispmap the dispatch map withd efinition of exposed services
-		* @param boolean $servicenow set to false to prevent the server from runnung upon construction
+		* @param array $dispmap the dispatch map with definition of exposed services
+		* @param boolean $servicenow set to false to prevent the server from running upon construction
 		*/
 		function xmlrpc_server($dispMap=null, $serviceNow=true)
 		{
@@ -541,7 +540,7 @@
 		* with the standard processing of the php function exposed as method. In
 		* particular, triggering an USER_ERROR level error will not halt script
 		* execution anymore, but just end up logged in the xmlrpc response)
-		* Note that info added at elevel 2 and 3 will be base64 encoded
+		* Note that info added at level 2 and 3 will be base64 encoded
 		* @access public
 		*/
 		function setDebug($in)
@@ -588,15 +587,7 @@
 			if ($data === null)
 			{
 				// workaround for a known bug in php ver. 5.2.2 that broke $HTTP_RAW_POST_DATA
-				$ver = phpversion();
-				if ($ver[0] >= 5)
-				{
-					$data = file_get_contents('php://input');
-				}
-				else
-				{
-					$data = isset($GLOBALS['HTTP_RAW_POST_DATA']) ? $GLOBALS['HTTP_RAW_POST_DATA'] : '';
-				}
+                $data = file_get_contents('php://input');
 			}
 			$raw_data = $data;
 
@@ -720,6 +711,7 @@
 		* Verify type and number of parameters received against a list of known signatures
 		* @param array $in array of either xmlrpcval objects or xmlrpc type definitions
 		* @param array $sig array of known signatures to match against
+		* @return array
 		* @access private
 		*/
 		function verifySignature($in, $sig)
@@ -785,7 +777,7 @@
 
 		/**
 		* Parse http headers received along with xmlrpc request. If needed, inflate request
-		* @return null on success or an xmlrpcresp
+		* @return mixed null on success or an xmlrpcresp
 		* @access private
 		*/
 		function parseRequestHeaders(&$data, &$req_encoding, &$resp_encoding, &$resp_compression)
@@ -936,26 +928,28 @@
 			$GLOBALS['_xh']['rt']='';
 
 			// decompose incoming XML into request structure
+
 			if ($req_encoding != '')
 			{
-				if (!in_array($req_encoding, array('UTF-8', 'ISO-8859-1', 'US-ASCII')))
-				// the following code might be better for mb_string enabled installs, but
-				// makes the lib about 200% slower...
-				//if (!is_valid_charset($req_encoding, array('UTF-8', 'ISO-8859-1', 'US-ASCII')))
-				{
-					error_log('XML-RPC: '.__METHOD__.': invalid charset encoding of received request: '.$req_encoding);
-					$req_encoding = $GLOBALS['xmlrpc_defencoding'];
-				}
-				/// @BUG this will fail on PHP 5 if charset is not specified in the xml prologue,
-				// the encoding is not UTF8 and there are non-ascii chars in the text...
-				/// @todo use an ampty string for php 5 ???
-				$parser = xml_parser_create($req_encoding);
-			}
-			else
-			{
-				$parser = xml_parser_create();
+                // Since parsing will fail if charset is not specified in the xml prologue,
+                // the encoding is not UTF8 and there are non-ascii chars in the text, we try to work round that...
+                // The following code might be better for mb_string enabled installs, but
+                // makes the lib about 200% slower...
+                //if (!is_valid_charset($req_encoding, array('UTF-8')))
+                if (!in_array($req_encoding, array('UTF-8', 'US-ASCII')) && !has_encoding($data)) {
+                    if ($req_encoding == 'ISO-8859-1') {
+                        $data = utf8_encode($data);
+                    } else {
+                        if (extension_loaded('mbstring')) {
+                            $data = mb_convert_encoding($data, 'UTF-8', $req_encoding);
+                        } else {
+                            error_log('XML-RPC: ' . __METHOD__ . ': invalid charset encoding of received request: ' . $req_encoding);
+                        }
+                    }
+                }
 			}
 
+			$parser = xml_parser_create();
 			xml_parser_set_option($parser, XML_OPTION_CASE_FOLDING, true);
 			// G. Giunta 2005/02/13: PHP internally uses ISO-8859-1, so we have to tell
 			// the xml parser to give us back data in the expected charset
@@ -1210,7 +1204,7 @@
 
 		/**
 		* add a string to the 'internal debug message' (separate from 'user debug message')
-		* @param string $strings
+		* @param string $string
 		* @access private
 		*/
 		function debugmsg($string)


### PR DESCRIPTION
Various updates to add support for UTF8 characters. While here update the xmlrpc library we use, tick up the version number (now 1.0.6) and finally update the copyright to 2016