### PR TITLE
Add new api calls

### DIFF
--- a/LICENSE.php
+++ b/LICENSE.php
@@ -21,7 +21,7 @@
  *            along with this program; if not, write to the Free Software
  *            Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
  *            MA 02110-1301, USA.
- * @version   1.0.6
+ * @version   1.0.7
  * @link      http://www.mailermailer.com/api/index.rwp
  */
 

--- a/MAILAPI_Client.php
+++ b/MAILAPI_Client.php
@@ -90,6 +90,48 @@ class MAILAPI_Client
     }
 
     /**
+    * Return a collection of member records.
+    * 
+    * @param int       $limit The maximum number of records to return, defaults to the maximum of 200
+    * @param int       $offset The starting point within the paginated results (use in combination with limit), defaults to 0
+    * @param timestamp $signup_after The starting signup time from which to return records, in UTC, e.g., 2016-03-30 14:15:30
+    * @param timestamp $singup_before The ending signup time from which to return records, in UTC, e.g., 2016-03-30 14:15:30
+    * @param timestamp $updated_after The starting last updated time from which to return records, in UTC, e.g., 2016-03-30 14:15:30
+    * @param timestamp $updated_before The ending last updated time from which to return records, in UTC, e.g., 2016-03-30 14:15:30
+    * @param timestamp $unsubscribed_after The starting unsubscribed time from which to return records, in UTC, e.g., 2016-03-30 14:15:30
+    * @param timestamp $unsubscribed_before The ending unsubscribed time from which to return records, in UTC, e.g., 2016-03-30 14:15:30 
+    * @return export_struct | MAILAPI_Error
+    */
+    public function getBulkMembers($limit = 200, $offset = 0, $signup_after, $signup_before, $updated_after, $updated_before, $unsubscribed_after, $unsubscribed_before)
+    {
+        $params                        = array();
+        $params['limit']               = php_xmlrpc_encode($limit);
+        $params['offset']              = php_xmlrpc_encode($offset);
+        $params['signup_after']        = php_xmlrpc_encode($signup_after);
+        $params['singup_before']       = php_xmlrpc_encode($signup_before);
+        $params['updated_after']       = php_xmlrpc_encode($updated_after);
+        $params['updated_before']      = php_xmlrpc_encode($updated_before);
+        $params['unsubscribed_after']  = php_xmlrpc_encode($unsubscribed_after);
+        $params['unsubscribed_before'] = php_xmlrpc_encode($unsubscribed_before);
+        $result = $this->mailapi_call->executeMethod('getBulkMembers', $params);
+        return $result;
+    }
+
+    /**
+    * Return the member record.
+    *
+    * @param string $user_token Either user_email, which is the member's email (e.g., johnsmith@email.com) or user_enc, which is the member's permanent id (e.g., 01234a-56789b)
+    * @return export_struct | MAILAPI_Error
+    */
+    public function getMember($user_token)
+    {
+        $params               = array();
+        $params['user_token'] = php_xmlrpc_encode($user_token);
+        $result = $this->mailapi_call->executeMethod('getMember', $params);
+        return $result;
+    }
+
+    /**
      * Unsubscribe a collection of member email addresses from the account list.
      *
      * @param string $user_emails emails of the members to unsubscribe
@@ -141,6 +183,26 @@ class MAILAPI_Client
     {
         $params                 = array();
         $params['user_email']   = php_xmlrpc_encode($user_email);
+        $result = $this->mailapi_call->executeMethod('unsuppressMember', $params);
+        return $result;
+    }
+
+    /**
+    * Update an existing specified list member.
+    *
+    * @param string $user_token Either user_email, which is the member's email (e.g., johnsmith@email.com) or user_enc, which is the member's permanent id (e.g., 01234a-56789b) 
+    * @param member_struct $member A single member record
+    * @param boolean $enforce_required Flag to control whether missing required fields as specified by account configuration should throw an exception, defaults to true
+    * @param boolean $send_invite Flag to control if double opt-in confirmation message is sent, defaults to true
+    * @return true | MAILAPI_Error
+    */
+    public function updateMember($user_token, $member, $enforced_required = true, $send_invite = true)
+    {
+        $params                     = array();
+        $params['user_token']       = php_xmlrpc_encode($user_token);
+        $params['member']           = php_xmlrpc_encode($member);
+        $params['enforce_required'] = php_xmlrpc_encode($enforce_required);
+        $params['send_invite']      = php_xmlrpc_encode($send_invite);
         $result = $this->mailapi_call->executeMethod('unsuppressMember', $params);
         return $result;
     }

--- a/MAILAPI_Client.php
+++ b/MAILAPI_Client.php
@@ -203,7 +203,7 @@ class MAILAPI_Client
         $params['member']           = php_xmlrpc_encode($member);
         $params['enforce_required'] = php_xmlrpc_encode($enforce_required);
         $params['send_invite']      = php_xmlrpc_encode($send_invite);
-        $result = $this->mailapi_call->executeMethod('unsuppressMember', $params);
+        $result = $this->mailapi_call->executeMethod('updateMember', $params);
         return $result;
     }
 }

--- a/MAILAPI_Client.php
+++ b/MAILAPI_Client.php
@@ -134,13 +134,13 @@ class MAILAPI_Client
     /**
      * Unsubscribe a collection of member email addresses from the account list.
      *
-     * @param string $user_emails emails of the members to unsubscribe
+     * @param array $user_tokens emails of the members to unsubscribe
      * @return true | MAILAPI_Error
      */
-    public function unsubBulkMembers($user_emails)
+    public function unsubBulkMembers($user_tokens)
     {
         $params                 = array();
-        $params['user_emails']   = php_xmlrpc_encode($user_emails);
+        $params['user_tokens']   = php_xmlrpc_encode($user_tokens);
         $result = $this->mailapi_call->executeMethod('unsubBulkMembers', $params);
         return $result;
     }
@@ -148,13 +148,13 @@ class MAILAPI_Client
     /**
      * Unsubscribe the email address from the account email list.
      *
-     * @param string $user_email email of the member to unsubscribe
+     * @param string $user_token Either user_email, which is the member's email (e.g., johnsmith@email.com) or user_enc, which is the member's permanent id (e.g., 01234a-56789b)
      * @return true | MAILAPI_Error
      */
-    public function unsubMember($user_email)
+    public function unsubMember($user_token)
     {
         $params                 = array();
-        $params['user_email']   = php_xmlrpc_encode($user_email);
+        $params['user_token']   = php_xmlrpc_encode($user_token);
         $result = $this->mailapi_call->executeMethod('unsubMember', $params);
         return $result;
     }
@@ -162,13 +162,13 @@ class MAILAPI_Client
     /**
      * Suppress the member email address.
      *
-     * @param string $user_email email of the member to suppress
+     * @param string $user_token Either user_email, which is the member's email (e.g., johnsmith@email.com) or user_enc, which is the member's permanent id (e.g., 01234a-56789b)
      * @return true | MAILAPI_Error
      */
-    public function suppressMember($user_email)
+    public function suppressMember($user_token)
     {
         $params                 = array();
-        $params['user_email']   = php_xmlrpc_encode($user_email);
+        $params['user_token']   = php_xmlrpc_encode($user_token);
         $result = $this->mailapi_call->executeMethod('suppressMember', $params);
         return $result;
     }
@@ -176,13 +176,13 @@ class MAILAPI_Client
     /**
      * Unsuppress the member email address.
      *
-     * @param string $user_email email of the member to unsuppress
+     * @param string $user_token Either user_email, which is the member's email (e.g., johnsmith@email.com) or user_enc, which is the member's permanent id (e.g., 01234a-56789b)
      * @return true | MAILAPI_Error
      */
-    public function unsuppressMember($user_email)
+    public function unsuppressMember($user_token)
     {
         $params                 = array();
-        $params['user_email']   = php_xmlrpc_encode($user_email);
+        $params['user_token']   = php_xmlrpc_encode($user_token);
         $result = $this->mailapi_call->executeMethod('unsuppressMember', $params);
         return $result;
     }

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # mailermailer-api-php
 
-A PHP wrapper using the [PHPXMLRPC](http://phpxmlrpc.sourceforge.net/) library to connect to the MailerMailer API.
+A PHP wrapper using the [PHPXMLRPC](http://phpxmlrpc.sourceforge.net/) library to connect to the MailerMailer API
 
 ##Requirements
 
@@ -8,7 +8,7 @@ PHP 5
 
 ## Installation
 
-Just place mailermailer-api-php in a directory accessible by your application
+Just place mailermailer-api-php in a directory accessible by your application.
 
 ## Usage
 

--- a/config.php
+++ b/config.php
@@ -5,7 +5,7 @@
 
 define('MAILAPI_ENDPOINT', 'https://api.mailermailer.com/1.0/');
 
-define('MAILAPI_VERSION', '1.0.6');
+define('MAILAPI_VERSION', '1.0.7');
 
 define ('MAILAPI_PARTNER', 'MM');
 

--- a/examples/getBulkMembers.php
+++ b/examples/getBulkMembers.php
@@ -1,0 +1,35 @@
+<?php
+
+include("../MAILAPI_Client.php");
+
+// Make sure we have an api key
+if (getenv('MAILAPI_KEY') == null) {
+  exit('Set setenv("MAILAPI_KEY") to use this example');
+}
+
+// Make sure we have an email address
+if (getenv('MAILAPI_TEST_EMAIL') == null) {
+  exit('Set setenv("MAILAPI_TEST_EMAIL") to use this example');
+}
+
+date_default_timezone_set('America/New_York');
+
+// Create our API object
+$mailapi = new MAILAPI_Client(getenv('MAILAPI_KEY'));
+
+// Get bulk members who signed up in the past year
+$date_after = date('Y-m-d H:i:s', time() - (365 * 24 * 60 * 60));
+$date_before = date('Y-m-d H:i:s', time());
+$response = $mailapi->getBulkMembers(10, 0, $date_after, $date_before, null, null, null, null);
+
+if (MAILAPI_Error::isError($response)) {
+    echo "Error \n";
+    echo "Code: " . $response->getErrorCode() . "\n";
+    echo "Message: ". $response->getErrorMessage() . "\n";
+} else {
+  echo "Got " . sizeof($response) . " members\n";
+  echo "Here are the members:\n";
+  var_dump($response);
+}
+
+?>

--- a/examples/getMember.php
+++ b/examples/getMember.php
@@ -1,0 +1,30 @@
+<?php
+
+include("../MAILAPI_Client.php");
+
+// Make sure we have an api key
+if (getenv('MAILAPI_KEY') == null) {
+  exit('Set setenv("MAILAPI_KEY") to use this example');
+}
+
+// Make sure we have an email address
+if (getenv('MAILAPI_TEST_EMAIL') == null) {
+  exit('Set setenv("MAILAPI_TEST_EMAIL") to use this example');
+}
+
+// Create our API object
+$mailapi = new MAILAPI_Client(getenv('MAILAPI_KEY'));
+
+// Add the member
+$response = $mailapi->getMember(getenv('MAILAPI_TEST_EMAIL'));
+
+// Evaluate response
+if (MAILAPI_Error::isError($response)) {
+    echo "Error \n";
+    echo "Code: " . $response->getErrorCode() . "\n";
+    echo "Message: ". $response->getErrorMessage() . "\n";
+} else {
+    echo "Success got member\n";
+}
+
+?>

--- a/examples/updateMember.php
+++ b/examples/updateMember.php
@@ -1,0 +1,49 @@
+<?php
+
+include("../MAILAPI_Client.php");
+
+// Make sure we have an api key
+if (getenv('MAILAPI_KEY') == null) {
+  exit('Set setenv("MAILAPI_KEY") to use this example');
+}
+
+// Make sure we have an email address
+if (getenv('MAILAPI_TEST_EMAIL') == null) {
+  exit('Set setenv("MAILAPI_TEST_EMAIL") to use this example');
+}
+
+$member = array();
+
+// Open text fields
+$member['user_email'] = getenv('MAILAPI_TEST_EMAIL');
+$member['user_fname'] = 'John';
+$member['user_lname'] = 'Doe';
+
+// Country
+$member['user_country'] = 'us';
+
+// State
+$member['user_state'] = 'md';
+
+// Category fields with multiple selection (checkboxes)
+$member['user_attr1'] = array('a','b','c','d');
+
+// Category fields with single selection (dropdown menu)
+$member['user_attr2'] = array('a');
+
+// Create our API object
+$mailapi = new MAILAPI_Client(getenv('MAILAPI_KEY'));
+
+// Update the member
+$response = $mailapi->updateMember(getenv('MAILAPI_TEST_EMAIL'), $member);
+
+// Evaluate response
+if (MAILAPI_Error::isError($response)) {
+    echo "Error \n";
+    echo "Code: " . $response->getErrorCode() . "\n";
+    echo "Message: ". $response->getErrorMessage() . "\n";
+} else {
+    echo "Success updated member\n";
+}
+
+?>

--- a/tests/GetBulkMembersTest.php
+++ b/tests/GetBulkMembersTest.php
@@ -1,0 +1,107 @@
+<?php
+
+require_once("test_config.php");
+
+class GetBulkMembers extends PHPUnit_Framework_TestCase
+{
+    protected $mailapi;
+    
+    protected $email1;
+    protected $email2;
+    protected $email3;
+
+    protected $member1;
+    protected $member2;
+    protected $member3;
+
+
+    protected function setUp()
+    {
+        include 'test_vars.php';
+
+        $this->mailapi = new MAILAPI_Client($test_apikey);
+
+        $this->email1 = $test_email1;
+        $this->email2 = $test_email2;
+        $this->email3 = $test_email3;
+
+        $formfields = $this->mailapi->getFormFields();
+
+        foreach ($formfields as $formfield) {
+            $value;
+            if ($formfield["type"] == 'select') {
+                if ($formfield["attributes"]["select_type"] == 'multi') {
+                    $value = array("a","b","c","d");            
+                } else {
+                    $value = array("a");
+                }
+            } elseif ($formfield["type"] == 'open_text') {
+                $value = "ANYTHING";
+            } elseif ($formfield["type"] == 'state') {
+                $value = "md";
+            } elseif ($formfield["type"] == 'country') {
+                $value = "us";
+            }
+            $this->member1[$formfield["fieldname"]] = $value;
+            $this->member2[$formfield["fieldname"]] = $value;
+            $this->member3[$formfield["fieldname"]] = $value;
+        }
+
+        $this->member1["user_email"] = $this->email1;
+        $this->member2["user_email"] = $this->email2;
+        $this->member3["user_email"] = $this->email3;
+
+        $response = $this->mailapi->addBulkMembers(array($this->member1, $this->member2, $this->member3));
+        $expected = array('added' => 3, 'updated' => 0, 'errors' => array(), 'report' => $response);
+        $this->assertEquals(1, $this->checkReport($expected));
+
+
+        
+        sleep(2);
+    }
+
+    public function testContainsNewMembers()
+    {
+        $date_after = date('Y-m-d H:i:s', time() - (60 * 60));
+        $date_before = date('Y-m-d H:i:s', time() + (60 * 60));
+
+        $response = $this->mailapi->getBulkMembers(200, 0, $date_after, $date_before, null, null, null, null);
+        $collectEmails = array_map(function($member){
+            return $member["user_email"];
+        }, $response);
+
+        $this->assertNotInstanceOf('MAILAPI_Error', $response);
+        $this->assertContains($this->email1, $collectEmails);
+        $this->assertContains($this->email2, $collectEmails);
+        $this->assertContains($this->email3, $collectEmails);
+    }
+
+    ///////////////////////////////////////////////////////////////
+    //
+    // HELPER FUNCTION
+    //
+    ////////////////////////////////////////////////////////////////
+    public function checkReport($params)
+    {
+        $added = $params["added"];
+        $updated = $params["updated"];
+        $errors = $params["errors"];
+
+        $report = $params["report"];
+        
+        if (count($errors)) {
+            foreach ($report["errors"] as $value) {
+                if ($errors[$value["email"]]) {
+                    if ($errors[$value["email"]] > 1) {
+                        $errors[$value["email"]]--;
+                    }
+                    else {
+                        unset($errors[$value["email"]]);
+                    }
+                }
+            }
+        }
+        return ($added == $report["added"] && $updated == $report["updated"] && count($errors) == 0);
+    }
+}
+?>

--- a/tests/GetMemberTest.php
+++ b/tests/GetMemberTest.php
@@ -2,7 +2,7 @@
 
 require_once("test_config.php");
 
-class UnsubMember extends PHPUnit_Framework_TestCase
+class GetMember extends PHPUnit_Framework_TestCase
 {
     protected $mailapi;
     protected $email;
@@ -40,43 +40,20 @@ class UnsubMember extends PHPUnit_Framework_TestCase
         $response = $this->mailapi->addMember($this->member);
         $this->assertEquals(1, $response);
         
-        sleep(1);
+        sleep(2);
     }
 
     public function testSuccess()
     {
-        $response = $this->mailapi->unsubMember($this->email);
-        $this->assertEquals(1, $response);
+        $response = $this->mailapi->getMember($this->email);
+        $this->assertNotInstanceOf('MAILAPI_Error', $response);
     }
 
-    public function testUnsubTwice()
+    public function testNonExistentUser()
     {
-        $response = $this->mailapi->unsubMember($this->email);
-        $this->assertEquals(1, $response);
-
-        $response = $this->mailapi->unsubMember($this->email);
-        $this->assertEquals(112, $response->getErrorCode());   
-    }
-
-    public function testUnsubNonexistentListMember()
-    {
-        $response = $this->mailapi->unsubMember("This email doesn't exist");
-        $this->assertEquals(302, $response->getErrorCode());        
-    }
-
-    public function testMissingFields()
-    {
-        $response = $this->mailapi->unsubMember("");
-        $this->assertEquals(301, $response->getErrorCode());   
-    }
-
-    public function testUnsubResub()
-    {
-        $response = $this->mailapi->unsubMember($this->email);
-        $this->assertEquals(1, $response);
-
-        $response = $this->mailapi->addMember($this->member);
-        $this->assertEquals(112, $response->getErrorCode());
+        $response = $this->mailapi->getMember('fake@email.com');
+        $this->assertEquals(305, $response->getErrorCode());
     }
 }
+
 ?>

--- a/tests/UnsubMemberTest.php
+++ b/tests/UnsubMemberTest.php
@@ -60,6 +60,12 @@ class UnsubMember extends PHPUnit_Framework_TestCase
 
     public function testUnsubNonexistentListMember()
     {
+        $response = $this->mailapi->unsubMember("fakeuser@email.com");
+        $this->assertEquals(305, $response->getErrorCode());        
+    }
+
+    public function testUnsubBadEmail()
+    {
         $response = $this->mailapi->unsubMember("This email doesn't exist");
         $this->assertEquals(302, $response->getErrorCode());        
     }

--- a/tests/UpdateMemberTest.php
+++ b/tests/UpdateMemberTest.php
@@ -2,7 +2,7 @@
 
 require_once("test_config.php");
 
-class UnsubMember extends PHPUnit_Framework_TestCase
+class UpdateMember extends PHPUnit_Framework_TestCase
 {
     protected $mailapi;
     protected $email;
@@ -40,43 +40,22 @@ class UnsubMember extends PHPUnit_Framework_TestCase
         $response = $this->mailapi->addMember($this->member);
         $this->assertEquals(1, $response);
         
-        sleep(1);
+        sleep(2);
     }
 
     public function testSuccess()
     {
-        $response = $this->mailapi->unsubMember($this->email);
-        $this->assertEquals(1, $response);
+        $response = $this->mailapi->updateMember($this->email, $this->member);
+        $this->assertNotInstanceOf('MAILAPI_Error', $response);
     }
 
-    public function testUnsubTwice()
+    public function testBadUpdate()
     {
-        $response = $this->mailapi->unsubMember($this->email);
-        $this->assertEquals(1, $response);
-
-        $response = $this->mailapi->unsubMember($this->email);
-        $this->assertEquals(112, $response->getErrorCode());   
-    }
-
-    public function testUnsubNonexistentListMember()
-    {
-        $response = $this->mailapi->unsubMember("This email doesn't exist");
-        $this->assertEquals(302, $response->getErrorCode());        
-    }
-
-    public function testMissingFields()
-    {
-        $response = $this->mailapi->unsubMember("");
-        $this->assertEquals(301, $response->getErrorCode());   
-    }
-
-    public function testUnsubResub()
-    {
-        $response = $this->mailapi->unsubMember($this->email);
-        $this->assertEquals(1, $response);
-
-        $response = $this->mailapi->addMember($this->member);
-        $this->assertEquals(112, $response->getErrorCode());
+        $bad_member = $this->member;
+        $bad_member["user_email"] = "bad value";
+        $response = $this->mailapi->updateMember($this->email, $bad_member);
+        $this->assertEquals(302, $response->getErrorCode());
     }
 }
+
 ?>

--- a/tests/test_vars.php
+++ b/tests/test_vars.php
@@ -12,7 +12,7 @@ if (getenv('MAILAPI_TEST_EMAIL') == null) {
   exit("Provide the test email address by setting MAILAPI_TEST_EMAIL env variable.\n");
 }
 
-date_default_timezone_set('America/New_York');
+date_default_timezone_set('UTC');
 
 $test_apikey = getenv('MAILAPI_KEY');
 

--- a/tests/test_vars.php
+++ b/tests/test_vars.php
@@ -12,6 +12,8 @@ if (getenv('MAILAPI_TEST_EMAIL') == null) {
   exit("Provide the test email address by setting MAILAPI_TEST_EMAIL env variable.\n");
 }
 
+date_default_timezone_set('America/New_York');
+
 $test_apikey = getenv('MAILAPI_KEY');
 
 $test_email1 = str_replace("@", "+php1" . md5(time()) . "@", getenv('MAILAPI_TEST_EMAIL'));


### PR DESCRIPTION
- Addition of 3 new API calls (getMember, getBulkMembers, updateMember)
- Altering of arguments relating to modifying of a specific user or users. Specifically we now accept user_token in place of user_email for unsubMember, suppressMember and also use it for the updateMember call.
- Updated all relevant tests and examples.
- Bumped up version to 1.0.7

@kamelkev @mailermailer 
